### PR TITLE
optional _defaultOptions

### DIFF
--- a/src/services/cookies.service.ts
+++ b/src/services/cookies.service.ts
@@ -5,7 +5,7 @@ import {CookieOptionsArgs} from './cookie-options-args.model';
 
 @Injectable()
 export class CookieService {
-  constructor(@Optional() private _defaultOptions: CookieOptions) {}
+  constructor(@Optional() private _defaultOptions?: CookieOptions) {}
 
   /**
    * @name CookieService#get


### PR DESCRIPTION
`_defaultOptions` now is "TypeScript-optional", which makes Angular 2 AoT work with this library
